### PR TITLE
background() and cornell_box (with 22 parameters) fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/joons/JRStatics.java
+++ b/joons/JRStatics.java
@@ -171,7 +171,7 @@ public class JRStatics {
 			"Joons-Renderer : float dark R, G, B, float maxDistance, int samples. (8 params)";
 	
 	public static final String CORNELL_BOX_ERROR =
-			"Joons-Renderer : ERROR, background type \"cornell_box\" must have 3, 7 or 21 parameters.\n" +
+			"Joons-Renderer : ERROR, background type \"cornell_box\" must have 3, 7 or 22 parameters.\n" +
 			"Joons-Renderer : float width, height, depth, (3 params) +\n" +
 			"Joons-Renderer : float radiance R, G, B, int samples, (7 params) +\n" + 
 			"Joons-Renderer : float left R, G, B, right R, G, B, back R, G, B, top R, G, B, bottom R, G, B. (21 params)";

--- a/joons/JoonsRenderer.java
+++ b/joons/JoonsRenderer.java
@@ -92,14 +92,18 @@ public class JoonsRenderer{
 		BG_R=gray/255f;
 		BG_G=gray/255f;
 		BG_B=gray/255f;
-		P.background(gray);
+		if (!rendering){
+			P.background(gray);
+		}
 	}
 	
 	public void background(float r, float g, float b){
 		BG_R=r/255f;
 		BG_G=g/255f;
 		BG_B=b/255f;
-		P.background(r,g,b);
+		if (!rendering){
+			P.background(r,g,b);
+		}
 	}
 	
 	public void background(String type){
@@ -148,7 +152,7 @@ public class JoonsRenderer{
 					cornellBox(params[0], params[1], params[2]);
 				} else if(params.length == 7) {
 					cornellBox(params[0], params[1], params[2], params[3], params[4], params[5], (int) params[6]);
-				} else if(params.length == 21) {
+				} else if(params.length == 22) {
 					cornellBox(params[0], params[1], params[2], params[3], params[4], params[5], (int) params[6],
 						params[7], params[8], params[9], params[10], params[11], params[12],
 						params[13], params[14], params[15], params[16], params[17], params[18],


### PR DESCRIPTION
background() issue: An error happens when JoonsRenderer.background() calls P.background() while rendering. Wrapping P.background() in a conditional seems to do the trick.

cornell_box issue: Just updated the correct number of parameters there.